### PR TITLE
add system.print()

### DIFF
--- a/core/src/main/java/ship/test/AergoMock.java
+++ b/core/src/main/java/ship/test/AergoMock.java
@@ -40,4 +40,13 @@ public class AergoMock {
     }
   };
 
+  public OneArgFunction print = new OneArgFunction() {
+    @Override
+    public LuaValue call(LuaValue msg) {
+      System.out.println(msg.tojstring());
+      logger.info(msg.tojstring());
+      return NIL;
+    }
+  };
+
 }

--- a/core/src/main/java/ship/test/Athena.java
+++ b/core/src/main/java/ship/test/Athena.java
@@ -31,8 +31,9 @@ public class Athena extends TwoArgFunction {
     final LuaValue system = tableOf();
     system.set("getItem", aergoMock.getItem);
     system.set("setItem", aergoMock.setItem);
-
+    system.set("print", aergoMock.print);
     env.set("system", system);
+
     return library;
   }
 }


### PR DESCRIPTION
This ensures that contracts using system.print won't break,
and that there is some mechanism for outputting to the logs
and STDOUT.  Test suites which wish to avoid this can stub
system.print, e.g.

    system.print = function(msg)
    end

or

    function stubPrint()
      system.origPrint = system.print
      system.print = function(msg)
        printOutput[#printOutput + 1] = msg
        -- We don't have the table library
        -- table.insert(printOutput, msg)
      end
    end

    function showPrintOutput()
      system.origPrint("captured:")
      for i, line in pairs(printOutput) do
        system.origPrint(line)
      end
      system.origPrint("--------")
    end

    function assertOutputContains(pattern)
      for i, line in pairs(printOutput) do
        if string.match(line, pattern) then
          return true
        end
      end
      error("Output did not contain '" .. pattern .. "'")
    end

    function resetOutputCapture()
      printOutput = {}
    end